### PR TITLE
RDS support + continuous backups

### DIFF
--- a/iam-service-role.tf
+++ b/iam-service-role.tf
@@ -23,56 +23,8 @@ module "backup_service_role" {
       }
     ]
   })
-  inline_policy = jsonencode({
-    Version : "2012-10-17"
-    Statement : [
-      {
-        Sid : "BackupVaultPermissions",
-        Effect : "Allow",
-        Action : [
-          "backup:DescribeBackupVault",
-          "backup:CopyIntoBackupVault"
-        ],
-        Resource : "arn:aws:backup:*:*:backup-vault:*"
-      },
-      {
-        Sid : "BackupVaultCopyPermissions",
-        Effect : "Allow",
-        Action : [
-          "backup:CopyFromBackupVault"
-        ],
-        Resource : "*"
-      },
-      {
-        Sid : "RecoveryPointTaggingPermissions",
-        Effect : "Allow",
-        Action : [
-          "backup:TagResource"
-        ],
-        Resource : "arn:aws:backup:*:*:recovery-point:*",
-        Condition : {
-          StringEquals : {
-            "aws:PrincipalAccount" : "$${aws:ResourceAccount}"
-          }
-        }
-      },
-      {
-        Sid : "KMSPermissions",
-        Effect : "Allow",
-        Action : "kms:DescribeKey",
-        Resource : "*"
-      },
-      {
-        Sid : "KMSCreateGrantPermissions",
-        Effect : "Allow",
-        Action : "kms:CreateGrant",
-        Resource : "*",
-        Condition : {
-          Bool : {
-            "kms:GrantIsForAWSResource" : "true"
-          }
-        }
-      }
-    ]
-  })
+  policy_arns = [
+    "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup",
+    "arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup"
+  ]
 }

--- a/modules/deployment-helper-lambda/lambda.tf
+++ b/modules/deployment-helper-lambda/lambda.tf
@@ -6,6 +6,7 @@ resource "aws_cloudwatch_log_group" "lambda" {
 data "archive_file" "lambda_code" {
   type        = "zip"
   source_dir  = "${path.module}/src"
+  excludes    = ["${path.module}/lambda.zip"]
   output_path = "${path.module}/lambda.zip"
 }
 

--- a/modules/service-deployment/backup-policies.tf
+++ b/modules/service-deployment/backup-policies.tf
@@ -30,7 +30,7 @@ locals {
     # If using a Logically Air Gapped Vault, we need separate plans for the resource selections
     local.create_lag_resources ? { for k, v in var.plans : "${k}-to-lag" => merge(v, { lag_plan : true, continuous_plan : false, tag_value : k }) if v["use_logically_air_gapped_vault"] } : {},
     # For resources that support continuous backup we want to create a continuous recovery point which the caller defined plans can then create snapshots from
-    { for k, v in var.plans : "${k}-continuous-backups" => merge(v, { lag_plan : false, continuous_plan : true, tag_value : k, rules : [{ name : "${k}-continuous-backups", schedule_expression : "cron(0 0 ? * * *)", delete_after_days : 35 }] }) },
+    { for k, v in var.plans : "${k}-continuous-backups" => merge(v, { lag_plan : false, continuous_plan : true, tag_value : k, rules : [{ name : "${k}-continuous-backups", schedule_expression : v["continuous_backup_schedule_expression"], delete_after_days : 35 }] }) if v["use_continuous_backups"] },
   )
 
   policy_content = jsonencode({

--- a/modules/service-deployment/backup-policies.tf
+++ b/modules/service-deployment/backup-policies.tf
@@ -20,7 +20,8 @@ locals {
     "arn:aws:ssm-sap:*:*:HANA/*",     # SAP HANA
   ]
   resource_types_with_continuous_backup_support = [
-    "arn:aws:s3:::*", # S3
+    "arn:aws:rds:*:*:db:*", # RDS Database Instance
+    "arn:aws:s3:::*",       # S3
   ]
 
   plans = merge(

--- a/modules/service-deployment/backup-policies.tf
+++ b/modules/service-deployment/backup-policies.tf
@@ -19,18 +19,27 @@ locals {
     "arn:aws:redshift:*:*:cluster:*", # Redshift
     "arn:aws:ssm-sap:*:*:HANA/*",     # SAP HANA
   ]
-  resource_types_with_continuous_backup_support = [
-    "arn:aws:rds:*:*:db:*", # RDS Database Instance
-    "arn:aws:s3:::*",       # S3
+  resource_types_that_snapshot_from_continuous_backups = [
+    # These resources support continuous backups and use these as a source for periodic backups.
+    "arn:aws:s3:::*", # S3
   ]
+  resource_types_with_continuous_backup_support = concat(
+    local.resource_types_that_snapshot_from_continuous_backups,
+    [
+      # These resources support continuous backups, but only for PITR recovery within the source account.
+      "arn:aws:rds:*:*:db:*",       # RDS Database Instance
+      "arn:aws:ssm-sap:*:*:HANA/*", # SAP HANA
+      # Aurora is not included as it can't be targetted by ARN
+    ]
+  )
 
   plans = merge(
     # Pass through the plans as defined by the caller
     { for k, v in var.plans : "${k}-to-standard" => merge(v, { lag_plan : false, continuous_plan : false, tag_value : k }) },
     # If using a Logically Air Gapped Vault, we need separate plans for the resource selections
     local.create_lag_resources ? { for k, v in var.plans : "${k}-to-lag" => merge(v, { lag_plan : true, continuous_plan : false, tag_value : k }) if v["use_logically_air_gapped_vault"] } : {},
-    # For resources that support continuous backup we want to create a continuous recovery point which the caller defined plans can then create snapshots from
-    { for k, v in var.plans : "${k}-continuous-backups" => merge(v, { lag_plan : false, continuous_plan : true, tag_value : k, rules : [{ name : "${k}-continuous-backups", schedule_expression : v["continuous_backup_schedule_expression"], delete_after_days : 35 }] }) if v["use_continuous_backups"] },
+    # If creating continuous backups, we need separate plans for the continuous backups - different lifecycle and they need to exist before the rules that snapshot from them.
+    { for k, v in var.plans : "${k}-continuous-backups" => merge(v, { lag_plan : false, continuous_plan : true, tag_value : k, rules : [{ name : "${k}-continuous-backups", schedule_expression : v["continuous_backup_schedule_expression"], delete_after_days : 35 }] }) if v["create_continuous_backups"] || v["snapshot_from_continuous_backups"] },
   )
 
   policy_content = jsonencode({
@@ -67,7 +76,12 @@ locals {
         "resources" : {
           "${plan["require_plan_name_resource_tag"] ? "supported-resources-with-tag" : "all-supported-resources"}" : {
             "iam_role_arn" : { "@@assign" : "arn:aws:iam::$account:role/${local.member_account_backup_service_role_name}" },
-            "resource_types" : { "@@assign" : plan["continuous_plan"] ? local.resource_types_with_continuous_backup_support : (plan["use_logically_air_gapped_vault"] ? (plan["lag_plan"] ? local.resource_types_with_lag_support : local.resource_types_without_lag_support) : ["*"]) },
+            "resource_types" : { "@@assign" : toset(concat(
+              plan["continuous_plan"] && plan["create_continuous_backups"] ? local.resource_types_with_continuous_backup_support : [],
+              plan["continuous_plan"] && plan["snapshot_from_continuous_backups"] ? local.resource_types_that_snapshot_from_continuous_backups : [],
+              plan["use_logically_air_gapped_vault"] && !plan["continuous_plan"] ? (plan["lag_plan"] ? local.resource_types_with_lag_support : local.resource_types_without_lag_support) : [],
+              !plan["continuous_plan"] && !plan["use_logically_air_gapped_vault"] ? ["*"] : [], # If not using LAG or continuous backups, select all resources
+            )) },
             "conditions" : !plan["require_plan_name_resource_tag"] ? {} : {
               "string_equals" : {
                 "require_resource_tag" : {
@@ -96,4 +110,13 @@ resource "aws_organizations_policy_attachment" "backup_policy" {
 
   policy_id = aws_organizations_policy.backup_policy.id
   target_id = each.key
+}
+
+
+
+
+
+resource "local_file" "backup_policy" {
+  content  = local.policy_content
+  filename = "${path.module}/${local.central_account_resource_name_prefix}.json"
 }

--- a/modules/service-deployment/sfn_backup_copy.tf
+++ b/modules/service-deployment/sfn_backup_copy.tf
@@ -47,6 +47,29 @@ module "backup_copier_sfn_role" {
         "Resource" : "*"
       },
       {
+        "Sid" : "AllowGetTags",
+        "Effect" : "Allow",
+        "Action" : [
+          "backup-gateway:ListTagsForResource",
+          "dsql:ListTagsForResource",
+          "dynamodb:ListTagsOfResource",
+          "ec2:DescribeTags",
+          "elasticfilesystem:DescribeTags",
+          "fsx:ListTagsForResource",
+          "fsx:ListTagsForResource",
+          "rds:ListTagsForResource",
+          "redshift-serverless:ListTagsForResource",
+          "redshift:DescribeTags",
+          "s3:GetBucketTagging",
+          "s3:GetObjectTagging",
+          "s3:GetObjectVersionTagging",
+          "ssm-sap:ListTagsForResource",
+          "storagegateway:ListTagsForResource",
+          "timestream:ListTagsForResource",
+        ],
+        "Resource" : "*"
+      },
+      {
         "Sid" : "AllowBackupCopyJob",
         "Effect" : "Allow",
         "Action" : [

--- a/modules/service-deployment/variables.tf
+++ b/modules/service-deployment/variables.tf
@@ -91,11 +91,13 @@ variable "min_retention_days" {
 variable "plans" {
   description = "A list of rules to be created for the backup plan."
   type = map(object({
-    require_plan_name_resource_tag = optional(bool, true)
-    use_logically_air_gapped_vault = optional(bool, false)
+    require_plan_name_resource_tag        = optional(bool, true),
+    use_continuous_backups                = optional(bool, true),                  # Use continuous backups for resources that support it. These backups do not copy but act as a source for the backup jobs created by the rules.
+    continuous_backup_schedule_expression = optional(string, "cron(0 0 ? * * *)"), # Schedule for creating continuous backups, if enabled.
+    use_logically_air_gapped_vault        = optional(bool, false),
     rules = list(object({
-      delete_after_days   = optional(number)
-      name                = optional(string)
+      delete_after_days   = optional(number),
+      name                = optional(string),
       schedule_expression = string
     }))
   }))

--- a/modules/service-deployment/variables.tf
+++ b/modules/service-deployment/variables.tf
@@ -91,9 +91,10 @@ variable "min_retention_days" {
 variable "plans" {
   description = "A list of rules to be created for the backup plan."
   type = map(object({
-    require_plan_name_resource_tag        = optional(bool, true),
-    use_continuous_backups                = optional(bool, true),                  # Use continuous backups for resources that support it. These backups do not copy but act as a source for the backup jobs created by the rules.
     continuous_backup_schedule_expression = optional(string, "cron(0 0 ? * * *)"), # Schedule for creating continuous backups, if enabled.
+    create_continuous_backups             = optional(bool, false),                 # Create continuous backups for resources that support it to enable local PITR, there is no copy action for these backups.
+    require_plan_name_resource_tag        = optional(bool, true),
+    snapshot_from_continuous_backups      = optional(bool, true), # Generate continuous backups for resources that support it and then snapshot from them. These backups do not copy but act as a source for the backup jobs created by the rules. Currently only S3 is supported.
     use_logically_air_gapped_vault        = optional(bool, false),
     rules = list(object({
       delete_after_days   = optional(number),

--- a/variables.tf
+++ b/variables.tf
@@ -9,8 +9,10 @@ variable "deployments" {
     max_retention_days = number,
     min_retention_days = number,
     plans = map(object({
-      require_plan_name_resource_tag = optional(bool, true),
-      use_logically_air_gapped_vault = optional(bool, false),
+      require_plan_name_resource_tag        = optional(bool, true),
+      use_continuous_backups                = optional(bool, true),                  # Use continuous backups for resources that support it. These backups do not copy but act as a source for the backup jobs created by the rules.
+      continuous_backup_schedule_expression = optional(string, "cron(0 0 ? * * *)"), # Schedule for creating continuous backups, if enabled.
+      use_logically_air_gapped_vault        = optional(bool, false),
       rules = list(object({
         schedule_expression = string,
         name                = string,

--- a/variables.tf
+++ b/variables.tf
@@ -9,9 +9,10 @@ variable "deployments" {
     max_retention_days = number,
     min_retention_days = number,
     plans = map(object({
-      require_plan_name_resource_tag        = optional(bool, true),
-      use_continuous_backups                = optional(bool, true),                  # Use continuous backups for resources that support it. These backups do not copy but act as a source for the backup jobs created by the rules.
       continuous_backup_schedule_expression = optional(string, "cron(0 0 ? * * *)"), # Schedule for creating continuous backups, if enabled.
+      create_continuous_backups             = optional(bool, false),                 # Create continuous backups for resources that support it to enable local PITR, there is no copy action for these backups.
+      require_plan_name_resource_tag        = optional(bool, true),
+      snapshot_from_continuous_backups      = optional(bool, true), # Generate continuous backups for resources that support it and then snapshot from them. These backups do not copy but act as a source for the backup jobs created by the rules. Currently only S3 is supported.
       use_logically_air_gapped_vault        = optional(bool, false),
       rules = list(object({
         schedule_expression = string,


### PR DESCRIPTION
- Fixes permissions to enable copying of RDS snapshots between accounts.
- Renames the `backup-copier` Step Function to `backup-ingest`.
- Excludes the Deployment Helper Lambda code package from the `archive_file` resource to reduce changes during repeated applies.
- Adds plan variable `continuous_backup_schedule_expression` to modify when continuous backups are scheduled, defaults to 00:00 UTC. Continuous backups do not copy to the central account, only the rules do; whilst testing with S3, continuous backups created multiple sequential jobs instead of choosing the backup with the longest lifecycle.
- Adds plan variable `create_continuous_backups` to enable/disable creating continuous backups for resource types that support same-account PITR (excluding AWS Aurora as we can't target this resource via ARN).
- Adds plan variable `snapshot_from_continuous_backups` to enable/disable creating continuous backups for resource types that then snapshot from the backup - currently only S3. This variable is operates independently of  `create_continuous_backups`.