### PR TITLE
DABACKUPS-59/backup-window-minutes

### DIFF
--- a/modules/service-deployment/backup-policies.tf
+++ b/modules/service-deployment/backup-policies.tf
@@ -45,12 +45,11 @@ locals {
   policy_content = jsonencode({
     "plans" : { for plan_name, plan in local.plans : plan_name => {
       "regions" : { "@@assign" : [data.aws_region.current.id] },
-      "rules" : { for rule_idx, rule in plan["rules"] : coalesce(rule["name"], rule_idx) => {
+      "rules" : { for rule_idx, rule in plan["rules"] : coalesce(rule["name"], rule_idx) => 
+        merge ( {
         "schedule_expression" : { "@@assign" : rule["schedule_expression"] },
         "target_backup_vault_name" : { "@@assign" : local.member_account_backup_vault_name },
         "enable_continuous_backup" : { "@@assign" : plan["continuous_plan"] },
-        "start_backup_window_minutes" : rule.start_backup_window_minutes != null ? { "@@assign" : rule.start_backup_window_minutes } : null,
-        "complete_backup_window_minutes" : rule.complete_backup_window_minutes != null ? { "@@assign" : rule.complete_backup_window_minutes } : null,
         "lifecycle" : {
           "delete_after_days" : { "@@assign" : rule["delete_after_days"] },
         },
@@ -63,7 +62,15 @@ locals {
           "${local.local_retention_days_tag}" : { "tag_key" : { "@@assign" : local.local_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["local_retention_days"], plan["local_retention_days"], rule["delete_after_days"], -1) } },
           "${local.intermediate_retention_days_tag}" : { "tag_key" : { "@@assign" : local.intermediate_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["intermediate_retention_days"], plan["intermediate_retention_days"], 7) } },
         }
-      } },
+      },
+      rule.start_backup_window_minutes != null ? {
+            "start_backup_window_minutes" : { "@@assign" : rule.start_backup_window_minutes }
+          } : {},
+      rule.complete_backup_window_minutes != null ? {
+            "complete_backup_window_minutes" : { "@@assign" : rule.complete_backup_window_minutes }
+          } : {}
+        )
+       },
       "selections" : {
         "resources" : {
           "${plan["require_plan_name_resource_tag"] ? "supported-resources-with-tag" : "all-supported-resources"}" : {

--- a/modules/service-deployment/backup-policies.tf
+++ b/modules/service-deployment/backup-policies.tf
@@ -49,7 +49,8 @@ locals {
         "schedule_expression" : { "@@assign" : rule["schedule_expression"] },
         "target_backup_vault_name" : { "@@assign" : local.member_account_backup_vault_name },
         "enable_continuous_backup" : { "@@assign" : plan["continuous_plan"] },
-        "start_backup_window_minutes" : { "@@assign" : 60 },
+        "start_backup_window_minutes" : rule.start_backup_window_minutes != null ? { "@@assign" : rule.start_backup_window_minutes } : null,
+        "complete_backup_window_minutes" : rule.complete_backup_window_minutes != null ? { "@@assign" : rule.complete_backup_window_minutes } : null,
         "lifecycle" : {
           "delete_after_days" : { "@@assign" : rule["delete_after_days"] },
         },

--- a/modules/service-deployment/backup-policies.tf
+++ b/modules/service-deployment/backup-policies.tf
@@ -45,32 +45,32 @@ locals {
   policy_content = jsonencode({
     "plans" : { for plan_name, plan in local.plans : plan_name => {
       "regions" : { "@@assign" : [data.aws_region.current.id] },
-      "rules" : { for rule_idx, rule in plan["rules"] : coalesce(rule["name"], rule_idx) => 
-        merge ( {
-        "schedule_expression" : { "@@assign" : rule["schedule_expression"] },
-        "target_backup_vault_name" : { "@@assign" : local.member_account_backup_vault_name },
-        "enable_continuous_backup" : { "@@assign" : plan["continuous_plan"] },
-        "lifecycle" : {
-          "delete_after_days" : { "@@assign" : rule["delete_after_days"] },
-        },
-        "copy_actions" : plan["continuous_plan"] ? {} : {
-          "${plan["lag_plan"] ? local.current_lag_vault.arn : aws_backup_vault.intermediate.arn}" : {
-            "target_backup_vault_arn" : { "@@assign" : plan["lag_plan"] ? local.current_lag_vault.arn : aws_backup_vault.intermediate.arn }
+      "rules" : { for rule_idx, rule in plan["rules"] : coalesce(rule["name"], rule_idx) =>
+        merge({
+          "schedule_expression" : { "@@assign" : rule["schedule_expression"] },
+          "target_backup_vault_name" : { "@@assign" : local.member_account_backup_vault_name },
+          "enable_continuous_backup" : { "@@assign" : plan["continuous_plan"] },
+          "lifecycle" : {
+            "delete_after_days" : { "@@assign" : rule["delete_after_days"] },
+          },
+          "copy_actions" : plan["continuous_plan"] ? {} : {
+            "${plan["lag_plan"] ? local.current_lag_vault.arn : aws_backup_vault.intermediate.arn}" : {
+              "target_backup_vault_arn" : { "@@assign" : plan["lag_plan"] ? local.current_lag_vault.arn : aws_backup_vault.intermediate.arn }
+            }
+          },
+          "recovery_point_tags" : (plan["lag_plan"] || plan["continuous_plan"]) ? {} : {
+            "${local.local_retention_days_tag}" : { "tag_key" : { "@@assign" : local.local_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["local_retention_days"], plan["local_retention_days"], rule["delete_after_days"], -1) } },
+            "${local.intermediate_retention_days_tag}" : { "tag_key" : { "@@assign" : local.intermediate_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["intermediate_retention_days"], plan["intermediate_retention_days"], 7) } },
           }
-        },
-        "recovery_point_tags" : (plan["lag_plan"] || plan["continuous_plan"]) ? {} : {
-          "${local.local_retention_days_tag}" : { "tag_key" : { "@@assign" : local.local_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["local_retention_days"], plan["local_retention_days"], rule["delete_after_days"], -1) } },
-          "${local.intermediate_retention_days_tag}" : { "tag_key" : { "@@assign" : local.intermediate_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["intermediate_retention_days"], plan["intermediate_retention_days"], 7) } },
-        }
-      },
-      rule.start_backup_window_minutes != null ? {
+          },
+          rule.start_backup_window_minutes != null ? {
             "start_backup_window_minutes" : { "@@assign" : rule.start_backup_window_minutes }
           } : {},
-      rule.complete_backup_window_minutes != null ? {
+          rule.complete_backup_window_minutes != null ? {
             "complete_backup_window_minutes" : { "@@assign" : rule.complete_backup_window_minutes }
           } : {}
         )
-       },
+      },
       "selections" : {
         "resources" : {
           "${plan["require_plan_name_resource_tag"] ? "supported-resources-with-tag" : "all-supported-resources"}" : {

--- a/modules/service-deployment/backup-policies.tf
+++ b/modules/service-deployment/backup-policies.tf
@@ -39,7 +39,7 @@ locals {
     # If using a Logically Air Gapped Vault, we need separate plans for the resource selections
     local.create_lag_resources ? { for k, v in var.plans : "${k}-to-lag" => merge(v, { lag_plan : true, continuous_plan : false, tag_value : k }) if v["use_logically_air_gapped_vault"] } : {},
     # If creating continuous backups, we need separate plans for the continuous backups - different lifecycle and they need to exist before the rules that snapshot from them.
-    { for k, v in var.plans : "${k}-continuous-backups" => merge(v, { lag_plan : false, continuous_plan : true, tag_value : k, rules : [{ name : "${k}-continuous-backups", schedule_expression : v["continuous_backup_schedule_expression"], delete_after_days : 35 }] }) if v["create_continuous_backups"] || v["snapshot_from_continuous_backups"] },
+    { for k, v in var.plans : "${k}-continuous-backups" => merge(v, { lag_plan : false, continuous_plan : true, tag_value : k, rules : [{ name : "${k}-continuous-backups", schedule_expression : v["continuous_backup_schedule_expression"], delete_after_days : 35, start_backup_window_minutes : null, complete_backup_window_minutes : null }] }) if v["create_continuous_backups"] || v["snapshot_from_continuous_backups"] },
   )
 
   policy_content = jsonencode({

--- a/modules/service-deployment/variables.tf
+++ b/modules/service-deployment/variables.tf
@@ -99,13 +99,13 @@ variable "plans" {
     snapshot_from_continuous_backups      = optional(bool, true), # Generate continuous backups for resources that support it and then snapshot from them. These backups do not copy but act as a source for the backup jobs created by the rules. Currently only S3 is supported.
     use_logically_air_gapped_vault        = optional(bool, false),
     rules = list(object({
-      delete_after_days           = optional(number) # Number of days to retain backups in the central vault, over
-      intermediate_retention_days = optional(number) # Number of days to retain backups in the intermediate vault, overrides the plan's intermediate_retention_days.
-      local_retention_days        = optional(number) # Number of days to retain backups in the member account vault. If not specified, defaults to delete_after_days.
-      start_backup_window_minutes = optional(number)
+      delete_after_days              = optional(number) # Number of days to retain backups in the central vault, over
+      intermediate_retention_days    = optional(number) # Number of days to retain backups in the intermediate vault, overrides the plan's intermediate_retention_days.
+      local_retention_days           = optional(number) # Number of days to retain backups in the member account vault. If not specified, defaults to delete_after_days.
+      start_backup_window_minutes    = optional(number)
       complete_backup_window_minutes = optional(number)
-      name                        = optional(string),
-      schedule_expression         = string,
+      name                           = optional(string),
+      schedule_expression            = string,
     }))
   }))
   default = {}

--- a/modules/service-deployment/variables.tf
+++ b/modules/service-deployment/variables.tf
@@ -102,6 +102,8 @@ variable "plans" {
       delete_after_days           = optional(number) # Number of days to retain backups in the central vault, over
       intermediate_retention_days = optional(number) # Number of days to retain backups in the intermediate vault, overrides the plan's intermediate_retention_days.
       local_retention_days        = optional(number) # Number of days to retain backups in the member account vault. If not specified, defaults to delete_after_days.
+      start_backup_window_minutes = optional(number)
+      complete_backup_window_minutes = optional(number)
       name                        = optional(string),
       schedule_expression         = string,
     }))

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.100.0"
+      version =  "~> 5.99.1" # temporary change the version is actually "~> 5.100.0" 
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version =  "~> 5.99.1" # temporary change the version is actually "~> 5.100.0" 
+      version = "~> 5.99.1" # temporary change the version is actually "~> 5.100.0" 
     }
   }
 }


### PR DESCRIPTION
I've updated the code in the backup-policies.tf file to allow the user to be able to set the value of the `start_backup_window_minutes` and `complete_backup_window_minutes` which then allows the default values of AWS to be used instead. Its also allows these two rules not appear in the backup policy itself.