### PR TITLE
DABACKUPS-60/backup tags recovery points

### DIFF
--- a/modules/service-deployment/backup-policies.tf
+++ b/modules/service-deployment/backup-policies.tf
@@ -60,14 +60,14 @@ locals {
         },
         "recovery_point_tags" : plan["continuous_plan"] ? {} : merge(
           {
-          "${local.local_retention_days_tag}" : { "tag_key" : { "@@assign" : local.local_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["local_retention_days"], plan["local_retention_days"], rule["delete_after_days"], -1) } 
-          }
-        },
-        (!plan["lag_plan"]) ? {
-          "${local.intermediate_retention_days_tag}" : { "tag_key" : { "@@assign" : local.intermediate_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["intermediate_retention_days"], plan["intermediate_retention_days"], 7) }
-          }
-        } : {}
-        ) 
+            "${local.local_retention_days_tag}" : { "tag_key" : { "@@assign" : local.local_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["local_retention_days"], plan["local_retention_days"], rule["delete_after_days"], -1) }
+            }
+          },
+          (!plan["lag_plan"]) ? {
+            "${local.intermediate_retention_days_tag}" : { "tag_key" : { "@@assign" : local.intermediate_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["intermediate_retention_days"], plan["intermediate_retention_days"], 7) }
+            }
+          } : {}
+        )
       } },
       "selections" : {
         "resources" : {

--- a/modules/service-deployment/backup-policies.tf
+++ b/modules/service-deployment/backup-policies.tf
@@ -59,14 +59,8 @@ locals {
           }
         },
         "recovery_point_tags" : plan["continuous_plan"] ? {} : merge(
-          {
-            "${local.local_retention_days_tag}" : { "tag_key" : { "@@assign" : local.local_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["local_retention_days"], plan["local_retention_days"], rule["delete_after_days"], -1) }
-            }
-          },
-          (!plan["lag_plan"]) ? {
-            "${local.intermediate_retention_days_tag}" : { "tag_key" : { "@@assign" : local.intermediate_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["intermediate_retention_days"], plan["intermediate_retention_days"], 7) }
-            }
-          } : {}
+          { "${local.local_retention_days_tag}" : { "tag_key" : { "@@assign" : local.local_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["local_retention_days"], plan["local_retention_days"], rule["delete_after_days"], -1) } } },
+          plan["lag_plan"] ? {} : { "${local.intermediate_retention_days_tag}" : { "tag_key" : { "@@assign" : local.intermediate_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["intermediate_retention_days"], plan["intermediate_retention_days"], 7) } } }
         )
       } },
       "selections" : {

--- a/modules/service-deployment/backup-policies.tf
+++ b/modules/service-deployment/backup-policies.tf
@@ -58,10 +58,16 @@ locals {
             "target_backup_vault_arn" : { "@@assign" : plan["lag_plan"] ? local.current_lag_vault.arn : aws_backup_vault.intermediate.arn }
           }
         },
-        "recovery_point_tags" : (plan["lag_plan"] || plan["continuous_plan"]) ? {} : {
-          "${local.local_retention_days_tag}" : { "tag_key" : { "@@assign" : local.local_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["local_retention_days"], plan["local_retention_days"], rule["delete_after_days"], -1) } },
-          "${local.intermediate_retention_days_tag}" : { "tag_key" : { "@@assign" : local.intermediate_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["intermediate_retention_days"], plan["intermediate_retention_days"], 7) } },
-        }
+        "recovery_point_tags" : plan["continuous_plan"] ? {} : merge(
+          {
+          "${local.local_retention_days_tag}" : { "tag_key" : { "@@assign" : local.local_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["local_retention_days"], plan["local_retention_days"], rule["delete_after_days"], -1) } 
+          }
+        },
+        (!plan["lag_plan"]) ? {
+          "${local.intermediate_retention_days_tag}" : { "tag_key" : { "@@assign" : local.intermediate_retention_days_tag }, "tag_value" : { "@@assign" : coalesce(rule["intermediate_retention_days"], plan["intermediate_retention_days"], 7) }
+          }
+        } : {}
+        ) 
       } },
       "selections" : {
         "resources" : {


### PR DESCRIPTION
I have added logic that will enable the user to use 2 paths which are 

- ember account to LAG, 
- or member account to intermediate to Standard. 

When the backup takes the latter path it will use the `BackupIntermediateRetentionDays` tag to change the retention period of the recovery point after being copied to the Standard Vault.