### PR TITLE
Fix Terraform's dependency graph during a destroy action

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,4 @@ module "service_deployment" {
   central_deployment_helper_topic_arn               = module.deployment_helper_lambda.sns_topic.arn
   member_account_deployment_helper_role_name_suffix = local.member_account_deployment_helper_role_name_suffix
   member_account_resource_name_prefix               = var.member_account_resource_name_prefix
-
-  depends_on = [module.deployment_helper_lambda]
 }

--- a/modules/deployment-helper-lambda/lambda.tf
+++ b/modules/deployment-helper-lambda/lambda.tf
@@ -30,6 +30,8 @@ resource "aws_lambda_function" "lambda" {
   ephemeral_storage {
     size = 1024
   }
+
+  depends_on = [aws_cloudwatch_log_group.lambda]
 }
 
 resource "aws_lambda_permission" "lambda" {
@@ -44,4 +46,6 @@ resource "aws_sns_topic_subscription" "lambda" {
   topic_arn = aws_sns_topic.lambda_invoke.arn
   protocol  = "lambda"
   endpoint  = aws_lambda_function.lambda.arn
+
+  depends_on = [aws_lambda_permission.lambda]
 }

--- a/modules/deployment-helper-lambda/outputs.tf
+++ b/modules/deployment-helper-lambda/outputs.tf
@@ -1,7 +1,19 @@
 output "lambda_role_arn" {
   value = module.lambda_role.role.arn
+
+  # Important: Ensures that the CloudFormation -> SNS -> Lambda pipeline works during a destroy.
+  depends_on = [
+    aws_sns_topic_policy.lambda_invoke,
+    aws_sns_topic_subscription.lambda
+  ]
 }
 
 output "sns_topic" {
   value = aws_sns_topic.lambda_invoke
+
+  # Important: Ensures that the CloudFormation -> SNS -> Lambda pipeline works during a destroy.
+  depends_on = [
+    aws_sns_topic_policy.lambda_invoke,
+    aws_sns_topic_subscription.lambda
+  ]
 }

--- a/modules/iam-role/outputs.tf
+++ b/modules/iam-role/outputs.tf
@@ -1,4 +1,10 @@
 output "role" {
   description = "The IAM role created by this module."
   value       = aws_iam_role.this
+
+  #Important: Ensures that the policies stay on the role until the role can be deleted.
+  depends_on = [
+    aws_iam_role_policy.this,
+    aws_iam_role_policy_attachment.this
+  ]
 }


### PR DESCRIPTION
Ensures that the Deployment Helper Lambda can still be invoked and has the correct permissions until the end.