### PR TITLE
Fix/cloudformation rollback

### DIFF
--- a/modules/deployment-helper-lambda/src/main.py
+++ b/modules/deployment-helper-lambda/src/main.py
@@ -38,9 +38,9 @@ def boto3_client(service, role_arn=None):
 
 
 def AWS__IAM__ServiceLinkedRole(event, context):
-    iam_client = boto3_client("iam", event["ResourceProperties"]["RoleArn"])
     match event["RequestType"]:
         case "Create" | "Update":
+            iam_client = boto3_client("iam", event["ResourceProperties"]["RoleArn"])
             service_name = event["ResourceProperties"]["AWSServiceName"]
             try:
                 LOGGER.info(

--- a/modules/deployment-helper-lambda/src/main.py
+++ b/modules/deployment-helper-lambda/src/main.py
@@ -81,12 +81,13 @@ def TerraformDeployment(event, context):
     # In the event of a rollback CloudFormation sends a Delete event with the PhysicalResourceId not set to the previous state file.
     if event["RequestType"] == "Delete" and not event["PhysicalResourceId"].startswith("s3://"):
         cfnresponse.send(
-        event,
-        context,
-        cfnresponse.SUCCESS,
-        {},
-        physicalResourceId=event["PhysicalResourceId"]
-    )
+            event,
+            context,
+            cfnresponse.SUCCESS,
+            {},
+            physicalResourceId=event["PhysicalResourceId"]
+        )
+        return
     tf_dir = "/tmp/terraform"
     tf_binary = os.path.join(tf_dir, "terraform")
     work_dir = os.path.join(tf_dir, "work")


### PR DESCRIPTION
- Protects Terraform deployed resources from being deleted after a failed update.
- Removes unnecessary `sts:AssumeRole` API call when deleting an IAM Service Linked Role.