### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tflint.yaml
+++ b/.github/workflows/tflint.yaml
@@ -3,6 +3,9 @@ name: Run TFLint
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   tflint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nationalarchives/terraform-aws-immutable-aws-backup/security/code-scanning/1](https://github.com/nationalarchives/terraform-aws-immutable-aws-backup/security/code-scanning/1)

To fix this issue, we should add an explicit `permissions` block in the workflow file. This block will limit the access of the `GITHUB_TOKEN` to the minimum required permissions. Based on the provided workflow, which involves checking out a repository and running TFLint, the workflow likely requires read permissions for the repository contents. Adding a `permissions` block at the root level will apply these restrictions to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
