### PR TITLE
Enable Compliance mode Vault Lock

### DIFF
--- a/modules/service-deployment-regional/backup-vaults.tf
+++ b/modules/service-deployment-regional/backup-vaults.tf
@@ -75,11 +75,11 @@ resource "aws_backup_vault" "standard" {
 resource "aws_backup_vault_lock_configuration" "standard" {
   for_each = toset(var.backup_vaults.standard_vaults)
 
-  region            = var.region
-  backup_vault_name = aws_backup_vault.standard[each.key].name
-  # changeable_for_days = 14
-  max_retention_days = split("-", each.key)[1]
-  min_retention_days = split("-", each.key)[0]
+  region              = var.region
+  backup_vault_name   = aws_backup_vault.standard[each.key].name
+  changeable_for_days = 3
+  max_retention_days  = split("-", each.key)[1]
+  min_retention_days  = split("-", each.key)[0]
 }
 
 #


### PR DESCRIPTION
We've been using Governance mode during development to allow rapid development, but we're now ready to enforce Compliance mode. Once the 3 day grace time expires on the vault, we will be unable to delete the vault or its contents until the vault is empty.