### PR TITLE
Add Step Function to copy backups back to workload accounts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,6 @@ module "deployment" {
   }
   central_account_resource_name_prefix                = var.central_account_resource_name_prefix
   central_backup_service_linked_role_arn              = local.backup_service_linked_role_arn
-  central_backup_service_role_arn                     = module.backup_service_role.role.arn
   central_deployment_helper_role_arn                  = module.deployment_helper.lambda_role.arn
   central_deployment_helper_topic_name                = module.deployment_helper.sns_topic.name
   deployment_regions                                  = local.deployment_regions

--- a/modules/service-deployment-regional/backup-vaults.tf
+++ b/modules/service-deployment-regional/backup-vaults.tf
@@ -12,7 +12,7 @@ locals {
         Resource : "*",
         Condition : {
           ArnLike : {
-            "aws:PrincipalArn" : "arn:${var.current_aws_partition}:iam::*:role/${var.member_account_backup_service_role_name}"
+            "aws:PrincipalArn" : "arn:${var.current.partition}:iam::*:role/${var.deployment.member_account_backup_service_role_name}"
           },
           "ForAnyValue:StringLike" : {
             "aws:PrincipalOrgPaths" : var.deployment.ou_paths_including_children

--- a/modules/service-deployment-regional/eventbridge.tf
+++ b/modules/service-deployment-regional/eventbridge.tf
@@ -22,7 +22,7 @@ resource "aws_cloudwatch_event_bus_policy" "event_bus" {
         Resource : "*",
         Condition : {
           ArnLike : {
-            "aws:PrincipalArn" : "arn:${var.current_aws_partition}:iam::*:role/${var.member_account_eventbridge_rule_name}",
+            "aws:PrincipalArn" : "arn:${var.current.partition}:iam::*:role/${var.deployment.member_account_eventbridge_rule_name}",
           },
           "ForAnyValue:StringLike" : {
             "aws:PrincipalOrgPaths" : var.deployment.ou_paths_including_children
@@ -93,7 +93,7 @@ resource "aws_cloudwatch_event_rule" "default_to_event_bus" {
     "detail-type" : ["Backup Job State Change", "Copy Job State Change"],
     "detail" : {
       "$or" : [
-        { "backupVaultName" : [var.member_account_backup_vault_name] },
+        { "backupVaultName" : [var.deployment.member_account_backup_vault_name] },
         { "sourceBackupVaultArn" : local.central_backup_vault_arns },
         { "destinationBackupVaultArn" : local.central_backup_vault_arns }
       ]

--- a/modules/service-deployment-regional/kms.tf
+++ b/modules/service-deployment-regional/kms.tf
@@ -1,5 +1,5 @@
 resource "aws_kms_replica_key" "key" {
-  count = var.region != var.current_aws_region ? 1 : 0
+  count = var.region != var.current.region ? 1 : 0
 
   region          = var.region
   primary_key_arn = var.kms.primary_key_arn
@@ -7,7 +7,7 @@ resource "aws_kms_replica_key" "key" {
 }
 
 resource "aws_kms_alias" "key" {
-  count = var.region != var.current_aws_region ? 1 : 0
+  count = var.region != var.current.region ? 1 : 0
 
   region        = var.region
   name          = var.kms.kms_key_alias

--- a/modules/service-deployment-regional/sfn_backup_restore.tf
+++ b/modules/service-deployment-regional/sfn_backup_restore.tf
@@ -41,7 +41,7 @@ resource "aws_sfn_state_machine" "backup_restore" {
           "memberAccountBackupVaultName" : var.deployment.member_account_backup_vault_name,
           "memberAccountRestoreVaultName" : var.deployment.member_account_restore_vault_name,
           "standardBackupVaultArns" : values(aws_backup_vault.standard)[*].arn,
-          "waitSeconds" : 30
+          "waitSeconds" : 180
         },
         "Output" : "{% $states.input %}"
         "Next" : "SourceVault?"

--- a/modules/service-deployment-regional/sfn_backup_restore.tf
+++ b/modules/service-deployment-regional/sfn_backup_restore.tf
@@ -8,9 +8,8 @@ resource "aws_cloudwatch_log_group" "backup_restore" {
 }
 
 resource "aws_sfn_state_machine" "backup_restore" {
-  name = var.stepfunctions.restore_state_machine_name
-  #TODO: Fix this
-  role_arn = var.stepfunctions.ingest_state_machine_role_arn
+  name     = var.stepfunctions.restore_state_machine_name
+  role_arn = var.stepfunctions.restore_state_machine_role_arn
 
   logging_configuration {
     level                  = "ALL"

--- a/modules/service-deployment-regional/sfn_backup_restore.tf
+++ b/modules/service-deployment-regional/sfn_backup_restore.tf
@@ -1,0 +1,195 @@
+#
+# Step Function to copy backups to member account restore vaults (...-default)
+#
+resource "aws_cloudwatch_log_group" "backup_restore" {
+  region            = var.region
+  name              = "/aws/vendedlogs/states/${var.stepfunctions.restore_state_machine_name}"
+  retention_in_days = 90
+}
+
+resource "aws_sfn_state_machine" "backup_restore" {
+  name = var.stepfunctions.restore_state_machine_name
+  #TODO: Fix this
+  role_arn = var.stepfunctions.ingest_state_machine_role_arn
+
+  logging_configuration {
+    level                  = "ALL"
+    include_execution_data = true
+    log_destination        = "${aws_cloudwatch_log_group.backup_restore.arn}:*"
+  }
+
+  /*
+  Step Function input:
+  {
+    "destinationAccount": "222222222222",
+    "recoveryPointArn": "arn:aws:backup:eu-west-2:111111111111:recovery-point:website-logs-20250708044140-61ebc5da",
+    "sourceBackupVaultName": "central-account-backup-vault"
+  }
+  */
+  definition = jsonencode({
+    "QueryLanguage" : "JSONata"
+    "StartAt" : "SetVars",
+    "States" : {
+      "SetVars" : {
+        "Type" : "Pass",
+        "Assign" : {
+          "accountId" : var.current.account_id,
+          "backupVaultArnPrefix" : "arn:${var.current.partition}:backup:${var.current.region}:<accountId>:backup-vault:",
+          "centralBackupServiceRoleArn" : var.deployment.backup_service_role_arn,
+          "iamRoleArnPrefix" : "arn:${var.current.partition}:iam::<accountId>:role/",
+          "intermediateBackupVaultArn" : aws_backup_vault.intermediate.arn,
+          "memberAccountBackupServiceRoleName" : var.deployment.member_account_backup_service_role_name,
+          "memberAccountBackupVaultName" : var.deployment.member_account_backup_vault_name,
+          "memberAccountRestoreVaultName" : var.deployment.member_account_restore_vault_name,
+          "standardBackupVaultArns" : values(aws_backup_vault.standard)[*].arn,
+          "waitSeconds" : 30
+        },
+        "Output" : "{% $states.input %}"
+        "Next" : "SourceVault?"
+      }
+      "SourceVault?" : {
+        "Type" : "Choice",
+        "Choices" : [
+          {
+            "Condition" : "{% ($replace($backupVaultArnPrefix, '<accountId>', $accountId) & $states.input.sourceBackupVaultName) in $standardBackupVaultArns %}",
+            "Next" : "StartCopyToIntermediateVault"
+          },
+          {
+            "Condition" : "{% ($replace($backupVaultArnPrefix, '<accountId>', $accountId) & $states.input.sourceBackupVaultName) = $intermediateBackupVaultArn %}",
+            "Next" : "StartCopyToDestinationAccountBackupVault"
+          }
+        ]
+      },
+      # Copy Standard -> Intermediate vault
+      "StartCopyToIntermediateVault" : {
+        "Type" : "Task",
+        "Resource" : "arn:aws:states:::aws-sdk:backup:startCopyJob",
+        "Arguments" : {
+          "DestinationBackupVaultArn" : "{% $intermediateBackupVaultArn %}",
+          "IamRoleArn" : "{% $centralBackupServiceRoleArn %}",
+          "RecoveryPointArn" : "{% $states.input.recoveryPointArn %}",
+          "SourceBackupVaultName" : "{% $states.input.sourceBackupVaultName %}",
+        },
+        "Output" : "{% $merge([$states.input, $states.result ]) %}",
+        "Next" : "WaitForCopyToIntermediateVault"
+      },
+      "WaitForCopyToIntermediateVault" : {
+        "Type" : "Wait",
+        "Seconds" : "{% $waitSeconds %}",
+        "Next" : "DescribeCopyToIntermediateVault"
+      }
+      "DescribeCopyToIntermediateVault" : {
+        "Type" : "Task",
+        "Resource" : "arn:aws:states:::aws-sdk:backup:describeCopyJob",
+        "Arguments" : {
+          "CopyJobId" : "{% $states.input.CopyJobId %}"
+        },
+        "Output" : "{% $merge([$states.input, $states.result ]) %}",
+        "Next" : "CopiedToIntermediateVault?"
+      },
+      "CopiedToIntermediateVault?" : {
+        "Type" : "Choice",
+        "Choices" : [
+          {
+            "Condition" : "{% $states.input.CopyJob.State = 'COMPLETED' %}",
+            "Next" : "StartCopyToDestinationAccountBackupVault"
+          },
+          {
+            "Condition" : "{% $states.input.CopyJob.State in ['CREATED', 'RUNNING'] %}",
+            "Next" : "WaitForCopyToIntermediateVault"
+          }
+        ],
+        "Default" : "Fail"
+      },
+      # Copy Intermediate -> Destination Account Backup vault
+      "StartCopyToDestinationAccountBackupVault" : {
+        "Type" : "Task",
+        "Resource" : "arn:aws:states:::aws-sdk:backup:startCopyJob",
+        "Arguments" : {
+          "DestinationBackupVaultArn" : "{% $replace($backupVaultArnPrefix, '<accountId>', $states.input.destinationAccount) & $memberAccountBackupVaultName %}",
+          "IamRoleArn" : "{% $centralBackupServiceRoleArn %}",
+          "RecoveryPointArn" : "{% $states.input.CopyJob ? $states.input.CopyJob.DestinationRecoveryPointArn : $states.input.recoveryPointArn %}",
+          "SourceBackupVaultName" : "{% $match($intermediateBackupVaultArn, /backup-vault:([^:]*)/).groups[0] %}",
+        },
+        "Output" : "{% $merge([$states.input, $states.result ]) %}",
+        "Next" : "WaitForCopyToDestinationAccountBackupVault"
+      },
+      "WaitForCopyToDestinationAccountBackupVault" : {
+        "Type" : "Wait",
+        "Seconds" : "{% $waitSeconds %}",
+        "Next" : "DescribeCopyToDestinationAccountBackupVault"
+      }
+      "DescribeCopyToDestinationAccountBackupVault" : {
+        "Type" : "Task",
+        "Resource" : "arn:aws:states:::aws-sdk:backup:describeCopyJob",
+        "Arguments" : {
+          "CopyJobId" : "{% $states.input.CopyJobId %}"
+        },
+        "Output" : "{% $merge([$states.input, $states.result ]) %}",
+        "Next" : "CopiedToDestinationAccountBackupVault?"
+      },
+      "CopiedToDestinationAccountBackupVault?" : {
+        "Type" : "Choice",
+        "Choices" : [
+          {
+            "Condition" : "{% $states.input.CopyJob.State = 'COMPLETED' %}",
+            "Next" : "StartCopyToDestinationAccountRestoreVault"
+          },
+          {
+            "Condition" : "{% $states.input.CopyJob.State in ['CREATED', 'RUNNING'] %}",
+            "Next" : "WaitForCopyToDestinationAccountBackupVault"
+          }
+        ],
+        "Default" : "Fail"
+      },
+      # Copy Destination Account Backup vault -> Destination Account Restore vault
+      "StartCopyToDestinationAccountRestoreVault" : {
+        "Type" : "Task",
+        "Resource" : "arn:aws:states:::aws-sdk:backup:startCopyJob",
+        "Credentials" : { "RoleArn" : "{% $replace($iamRoleArnPrefix, '<accountId>', $states.input.destinationAccount) & $memberAccountBackupServiceRoleName %}" },
+        "Arguments" : {
+          "DestinationBackupVaultArn" : "{% $replace($backupVaultArnPrefix, '<accountId>', $states.input.destinationAccount) & $memberAccountRestoreVaultName %}",
+          "IamRoleArn" : "{% $replace($iamRoleArnPrefix, '<accountId>', $states.input.destinationAccount) & $memberAccountBackupServiceRoleName  %}",
+          "RecoveryPointArn" : "{% $states.input.CopyJob ? $states.input.CopyJob.DestinationRecoveryPointArn : $states.input.recoveryPointArn %}",
+          "SourceBackupVaultName" : "{% $memberAccountBackupVaultName %}",
+        },
+        "Output" : "{% $merge([$states.input, $states.result ]) %}",
+        "Next" : "WaitForCopyToDestinationAccountRestoreVault"
+      },
+      "WaitForCopyToDestinationAccountRestoreVault" : {
+        "Type" : "Wait",
+        "Seconds" : "{% $waitSeconds %}",
+        "Next" : "DescribeCopyToDestinationAccountRestoreVault"
+      }
+      "DescribeCopyToDestinationAccountRestoreVault" : {
+        "Type" : "Task",
+        "Resource" : "arn:aws:states:::aws-sdk:backup:describeCopyJob",
+        "Arguments" : {
+          "CopyJobId" : "{% $states.input.CopyJobId %}"
+        },
+        "Output" : "{% $merge([$states.input, $states.result ]) %}",
+        "Next" : "CopiedToDestinationAccountRestoreVault?"
+      },
+      "CopiedToDestinationAccountRestoreVault?" : {
+        "Type" : "Choice",
+        "Choices" : [
+          {
+            "Condition" : "{% $states.input.CopyJob.State = 'COMPLETED' %}",
+            "Next" : "Succeed"
+          },
+          {
+            "Condition" : "{% $states.input.CopyJob.State in ['CREATED', 'RUNNING'] %}",
+            "Next" : "WaitForCopyToDestinationAccountRestoreVault"
+          }
+        ],
+        "Default" : "Fail"
+      },
+      "Succeed" : {
+        "Type" : "Succeed"
+      },
+      "Fail" : {
+        "Type" : "Fail",
+      },
+    }
+  })
+}

--- a/modules/service-deployment-regional/variables.tf
+++ b/modules/service-deployment-regional/variables.tf
@@ -16,25 +16,23 @@ variable "backup_vaults" {
   })
 }
 
-variable "current_aws_account_id" {
-  description = "The AWS account ID where Terraform is being executed."
-  type        = string
-}
-
-variable "current_aws_partition" {
-  description = "The current AWS partition (e.g., aws, aws-cn, aws-us-gov) where Terraform is being executed."
-  type        = string
-}
-
-variable "current_aws_region" {
-  description = "The current AWS region where Terraform is being executed."
-  type        = string
+variable "current" {
+  description = "The current AWS account ID, organization, partition, and region."
+  type = object({
+    account_id : string
+    partition : string
+    region : string
+  })
 }
 
 variable "deployment" {
   type = object({
-    backup_service_role_arn     = string
-    ou_paths_including_children = list(string),
+    backup_service_role_arn                 = string
+    member_account_backup_service_role_name = string
+    member_account_backup_vault_name        = string
+    member_account_eventbridge_rule_name    = string
+    member_account_restore_vault_name       = string
+    ou_paths_including_children             = list(string)
   })
 }
 
@@ -52,21 +50,6 @@ variable "kms" {
     kms_key_policy  = string
     primary_key_arn = string
   })
-}
-
-variable "member_account_backup_service_role_name" {
-  description = "The name of the backup service role in member accounts."
-  type        = string
-}
-
-variable "member_account_eventbridge_rule_name" {
-  description = "The name of the EventBridge rule in member accounts."
-  type        = string
-}
-
-variable "member_account_backup_vault_name" {
-  description = "The name of the backup vault in member accounts."
-  type        = string
 }
 
 variable "ram" {
@@ -88,6 +71,8 @@ variable "stepfunctions" {
     ingest_state_machine_name          = string
     ingest_state_machine_role_arn      = string
     ingest_state_role_arn              = string
+    restore_state_machine_name         = string
+    restore_state_machine_role_arn     = string
   })
 }
 

--- a/modules/service-deployment/iam-service-role.tf
+++ b/modules/service-deployment/iam-service-role.tf
@@ -1,11 +1,12 @@
 #
-# Creates a service role for AWS Backup.
+# Creates a service role for AWS Backup
+# One per deployment to restrict permissions for copying back to member accounts
 #
 
 module "backup_service_role" {
-  source = "./modules/iam-role"
+  source = "../iam-role"
 
-  name = join("", [var.central_account_resource_name_prefix, "backup-service-role"])
+  name = join("", [local.central_account_resource_name_prefix, "backup-service-role"])
   assume_role_policy = jsonencode({
     Version : "2012-10-17"
     Statement : [
@@ -17,7 +18,7 @@ module "backup_service_role" {
         Action : "sts:AssumeRole",
         Condition : {
           StringEquals : {
-            "aws:SourceAccount" : local.account_id
+            "aws:SourceAccount" : var.current.account_id
           }
         }
       }

--- a/modules/service-deployment/iam-service-role.tf
+++ b/modules/service-deployment/iam-service-role.tf
@@ -6,7 +6,7 @@
 module "backup_service_role" {
   source = "../iam-role"
 
-  name = join("", [local.central_account_resource_name_prefix, "backup-service-role"])
+  name = join("", [local.central_account_resource_name_prefix, "-backup-service-role"])
   assume_role_policy = jsonencode({
     Version : "2012-10-17"
     Statement : [

--- a/modules/service-deployment/iam-sfn-backup-ingest.tf
+++ b/modules/service-deployment/iam-sfn-backup-ingest.tf
@@ -60,69 +60,8 @@ module "backup_ingest_sfn_role" {
   })
   inline_policy = jsonencode({
     Version : "2012-10-17"
-    Statement : [
-      {
-        "Sid" : "AllowLogDelivery",
-        "Effect" : "Allow",
-        "Action" : [
-          "logs:CreateLogDelivery",
-          "logs:CreateLogStream",
-          "logs:GetLogDelivery",
-          "logs:UpdateLogDelivery",
-          "logs:DeleteLogDelivery",
-          "logs:ListLogDeliveries",
-          "logs:PutLogEvents",
-          "logs:PutResourcePolicy",
-          "logs:DescribeResourcePolicies",
-          "logs:DescribeLogGroups"
-        ],
-        "Resource" : "*"
-      },
-      {
-        "Sid" : "AllowBackupCopyJob",
-        "Effect" : "Allow",
-        "Action" : [
-          "backup:DescribeCopyJob",
-          "backup:StartCopyJob",
-          "backup:UpdateRecoveryPointLifecycle",
-          "backup:ListTags"
-        ],
-        "Resource" : "*"
-      },
-      {
-        "Sid" : "AllowBackupVaultAccess",
-        "Effect" : "Allow",
-        "Action" : [
-          "backup:DescribeBackupVault",
-          "backup:ListRecoveryPointsByBackupVault"
-        ],
-        "Resource" : flatten([
-          [for i in var.deployment_regions : replace(local.current_standard_vault_arn_template, "<REGION>", i)],
-          [for i in var.deployment_regions : replace(local.intermediate_vault_arn_template, "<REGION>", i)],
-        ])
-      },
-      {
-        "Sid" : "AllowPassRole",
-        "Effect" : "Allow",
-        "Action" : [
-          "iam:PassRole"
-        ],
-        "Resource" : module.backup_service_role.role.arn
-      },
-      {
-        Sid : "AllowAssumeRoleInMemberAccounts",
-        Effect : "Allow",
-        Action : [
-          "sts:AssumeRole"
-        ],
-        Resource : "arn:aws:iam::*:role/${local.member_account_backup_service_role_name}",
-        Condition : {
-          "ForAnyValue:StringLike" : {
-            "aws:ResourceOrgPaths" : local.deployment_ou_paths_including_children
-          }
-        }
-      }
-    ]
+    Statement : local.step_function_role_policy_statements
+    # Can assume the backup_ingest_sfn_state_role through same-account trust policy
   })
 }
 

--- a/modules/service-deployment/iam-sfn-backup-ingest.tf
+++ b/modules/service-deployment/iam-sfn-backup-ingest.tf
@@ -107,7 +107,7 @@ module "backup_ingest_sfn_role" {
         "Action" : [
           "iam:PassRole"
         ],
-        "Resource" : var.central_backup_service_role_arn
+        "Resource" : module.backup_service_role.role.arn
       },
       {
         Sid : "AllowAssumeRoleInMemberAccounts",

--- a/modules/service-deployment/iam-sfn-backup-restore.tf
+++ b/modules/service-deployment/iam-sfn-backup-restore.tf
@@ -1,0 +1,47 @@
+#
+# Role for the Backup Restore Step Function to assume
+#
+module "backup_restore_sfn_role" {
+  source = "../iam-role"
+
+  name = "${local.restore_state_machine_name}-sfn"
+  assume_role_policy = jsonencode({
+    Version : "2012-10-17"
+    Statement : [
+      {
+        Effect = "Allow"
+        Principal : {
+          Service : "states.amazonaws.com"
+        }
+        Action : "sts:AssumeRole",
+        Condition : {
+          StringEquals : {
+            "aws:SourceAccount" : var.current.account_id
+          }
+        }
+      }
+    ]
+  })
+  inline_policy = jsonencode({
+    Version : "2012-10-17"
+    Statement : [
+      {
+        "Sid" : "AllowLogDelivery",
+        "Effect" : "Allow",
+        "Action" : [
+          "logs:CreateLogDelivery",
+          "logs:CreateLogStream",
+          "logs:GetLogDelivery",
+          "logs:UpdateLogDelivery",
+          "logs:DeleteLogDelivery",
+          "logs:ListLogDeliveries",
+          "logs:PutLogEvents",
+          "logs:PutResourcePolicy",
+          "logs:DescribeResourcePolicies",
+          "logs:DescribeLogGroups"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}

--- a/modules/service-deployment/iam-sfn-backup-restore.tf
+++ b/modules/service-deployment/iam-sfn-backup-restore.tf
@@ -24,24 +24,6 @@ module "backup_restore_sfn_role" {
   })
   inline_policy = jsonencode({
     Version : "2012-10-17"
-    Statement : [
-      {
-        "Sid" : "AllowLogDelivery",
-        "Effect" : "Allow",
-        "Action" : [
-          "logs:CreateLogDelivery",
-          "logs:CreateLogStream",
-          "logs:GetLogDelivery",
-          "logs:UpdateLogDelivery",
-          "logs:DeleteLogDelivery",
-          "logs:ListLogDeliveries",
-          "logs:PutLogEvents",
-          "logs:PutResourcePolicy",
-          "logs:DescribeResourcePolicies",
-          "logs:DescribeLogGroups"
-        ],
-        "Resource" : "*"
-      }
-    ]
+    Statement : local.step_function_role_policy_statements
   })
 }

--- a/modules/service-deployment/kms.tf
+++ b/modules/service-deployment/kms.tf
@@ -79,8 +79,7 @@ locals {
             "kms:GrantIsForAWSResource" : "true"
           },
           "ForAnyValue:StringLike" : {
-            "aws:PrincipalOrgPaths" : local.deployment_ou_paths_including_children,
-            "kms:ViaService" : "backup.*.amazonaws.com"
+            "aws:PrincipalOrgPaths" : local.deployment_ou_paths_including_children
           }
         }
       }

--- a/modules/service-deployment/locals.tf
+++ b/modules/service-deployment/locals.tf
@@ -38,4 +38,72 @@ locals {
     [for i in local.standard_vaults : join("", [local.central_backup_vault_arn_prefix_template, local.standard_vault_prefix, i])],
     [for i in local.lag_vaults : join("", [local.central_backup_vault_arn_prefix_template, local.lag_vault_prefix, i])]
   ])
+
+
+  #
+  # Base policy statements for Step Function Roles
+  #
+  step_function_role_policy_statements = [
+    {
+      "Sid" : "AllowLogDelivery",
+      "Effect" : "Allow",
+      "Action" : [
+        "logs:CreateLogDelivery",
+        "logs:CreateLogStream",
+        "logs:GetLogDelivery",
+        "logs:UpdateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:PutLogEvents",
+        "logs:PutResourcePolicy",
+        "logs:DescribeResourcePolicies",
+        "logs:DescribeLogGroups"
+      ],
+      "Resource" : "*"
+    },
+    {
+      "Sid" : "AllowBackupCopyJob",
+      "Effect" : "Allow",
+      "Action" : [
+        "backup:DescribeCopyJob",
+        "backup:StartCopyJob",
+        "backup:UpdateRecoveryPointLifecycle",
+        "backup:ListTags"
+      ],
+      "Resource" : "*"
+    },
+    {
+      "Sid" : "AllowPassRole",
+      "Effect" : "Allow",
+      "Action" : [
+        "iam:PassRole"
+      ],
+      "Resource" : module.backup_service_role.role.arn
+    },
+    {
+      "Sid" : "AllowBackupVaultAccess",
+      "Effect" : "Allow",
+      "Action" : [
+        "backup:DescribeBackupVault",
+        "backup:ListRecoveryPointsByBackupVault"
+      ],
+      "Resource" : flatten([
+        [for i in var.deployment_regions : replace(local.current_standard_vault_arn_template, "<REGION>", i)],
+        [for i in var.deployment_regions : replace(local.intermediate_vault_arn_template, "<REGION>", i)],
+      ])
+    },
+    {
+      Sid : "AllowAssumeRoleInMemberAccounts",
+      Effect : "Allow",
+      Action : [
+        "sts:AssumeRole"
+      ],
+      Resource : "arn:aws:iam::*:role/${local.member_account_backup_service_role_name}",
+      Condition : {
+        "ForAnyValue:StringLike" : {
+          "aws:ResourceOrgPaths" : local.deployment_ou_paths_including_children
+        }
+      }
+    }
+  ]
 }

--- a/modules/service-deployment/locals.tf
+++ b/modules/service-deployment/locals.tf
@@ -5,6 +5,7 @@ locals {
   central_account_resource_name_prefix = "${var.central_account_resource_name_prefix}${var.service_name}"
   event_bus_name                       = local.central_account_resource_name_prefix
   ingest_state_machine_name            = join("", [local.central_account_resource_name_prefix, "-backup-ingest"])
+  restore_state_machine_name           = join("", [local.central_account_resource_name_prefix, "-backup-restore"])
   lag_share_name                       = local.central_account_resource_name_prefix
 
   member_account_resource_name_prefix     = join("", [var.member_account_resource_name_prefix, var.service_name])

--- a/modules/service-deployment/regional.tf
+++ b/modules/service-deployment/regional.tf
@@ -33,7 +33,7 @@ module "region" {
     standard_vaults             = local.standard_vaults
   }
   deployment = {
-    backup_service_role_arn     = var.central_backup_service_role_arn
+    backup_service_role_arn     = module.backup_service_role.role.arn
     ou_paths_including_children = local.deployment_ou_paths_including_children
   }
   eventbridge = {

--- a/modules/service-deployment/regional.tf
+++ b/modules/service-deployment/regional.tf
@@ -11,15 +11,7 @@ module "region" {
   source   = "../service-deployment-regional"
   for_each = toset(var.deployment_regions)
 
-  region                 = each.value
-  current_aws_account_id = var.current.account_id
-  current_aws_partition  = var.current.partition
-  current_aws_region     = var.current.region
-
-  member_account_backup_service_role_name = local.member_account_backup_service_role_name
-  member_account_eventbridge_rule_name    = local.member_account_eventbridge_rule_name
-  member_account_backup_vault_name        = local.member_account_backup_vault_name
-
+  region = each.value
   backup_policies = {
     intermediate_retention_days_tag = local.intermediate_retention_days_tag
     local_retention_days_tag        = local.local_retention_days_tag
@@ -32,9 +24,18 @@ module "region" {
     standard_vault_prefix       = local.standard_vault_prefix
     standard_vaults             = local.standard_vaults
   }
+  current = {
+    account_id = var.current.account_id
+    partition  = var.current.partition
+    region     = each.value
+  }
   deployment = {
-    backup_service_role_arn     = module.backup_service_role.role.arn
-    ou_paths_including_children = local.deployment_ou_paths_including_children
+    backup_service_role_arn                 = module.backup_service_role.role.arn
+    member_account_backup_service_role_name = local.member_account_backup_service_role_name
+    member_account_eventbridge_rule_name    = local.member_account_eventbridge_rule_name
+    member_account_backup_vault_name        = local.member_account_backup_vault_name
+    member_account_restore_vault_name       = local.member_account_restore_vault_name
+    ou_paths_including_children             = local.deployment_ou_paths_including_children
   }
   eventbridge = {
     bus_name               = local.event_bus_name
@@ -56,5 +57,7 @@ module "region" {
     ingest_state_machine_role_arn      = module.backup_ingest_sfn_role.role.arn
     ingest_state_role_arn              = module.backup_ingest_sfn_state_role.role.arn
     ingest_eventbridge_target_role_arn = module.backup_ingest_eventbridge_role.role.arn
+    restore_state_machine_name         = local.restore_state_machine_name
+    restore_state_machine_role_arn     = module.backup_restore_sfn_role.role.arn
   }
 }

--- a/modules/service-deployment/templates/stackset.json.tftpl
+++ b/modules/service-deployment/templates/stackset.json.tftpl
@@ -1,4 +1,7 @@
-{
+${jsonencode({
+  # This is a Terraform template file to create an AWS CloudFormation template; it uses the jsonencode function to export the template as JSON.
+  # Use of CloudFormation pseudo parameters must be escaped from Terraform with `$$`. For example, `$${AWS::Region}`.
+
   "AWSTemplateFormatVersion": "2010-09-09",
   "Parameters": {
     "BackupServiceRoleName": {
@@ -20,6 +23,9 @@
     "CentralAccountId": {
       "Type": "String",
       "Description": "The AWS Account ID of the central account."
+    },
+    "CentralBackupServiceRoleArn": {
+      "Type": "String"
     },
     "EventBusName": {
       "Type": "String"
@@ -112,12 +118,35 @@
               "Version": "2012-10-17",
               "Statement": [
                 {
+                  "Sid": "AllowUpdateLifecycle",
                   "Effect": "Allow",
                   "Action": [
-                    "backup:UpdateRecoveryPointLifecycle",
-                    "backup:ListTags"
+                    "backup:UpdateRecoveryPointLifecycle"
                   ],
                   "Resource": "*"
+                },
+                {
+                  "Sid": "AllowStartCopy",
+                  "Effect": "Allow",
+                  "Action": [
+                    "backup:DescribeCopyJob",
+                    "backup:ListTags",
+                    "backup:StartCopyJob"
+                  ],
+                  "Resource": "*"
+                },
+                {
+                  "Sid": "AllowPassSelfToCopyJobs",
+                  "Effect": "Allow",
+                  "Action": [
+                    "iam:PassRole"
+                  ],
+                  "Resource": { "Fn::Sub": "arn:$${AWS::Partition}:iam::$${AWS::AccountId}:role/$${BackupServiceRoleName}" },
+                  "Condition": {
+                    "StringEquals": {
+                      "iam:PassedToService": "backup.amazonaws.com"
+                    }
+                  }
                 }
               ]
             }
@@ -189,6 +218,7 @@
             "Version": "2012-10-17",
             "Statement": [
               {
+                "Sid": "ProtectVaultAndContents",
                 "Effect": "Deny",
                 "Principal": {
                   "AWS": "*"
@@ -210,13 +240,18 @@
                 "Resource": "*",
                 "Condition": {
                   "ArnNotLike": {
-                    "aws:PrincipalArn": [
-                      { "Fn::GetAtt": ["DeploymentHelperRole", "Arn"] },
-                      { "Fn::Sub": "arn:$${AWS::Partition}:iam::$${AWS::AccountId}:role/$${BackupServiceRoleName}" },
-                      { "Fn::Sub": "arn:$${AWS::Partition}:iam::$${AWS::AccountId}:role/OrganizationAccountAccessRole" }
-                    ]
+                    "aws:PrincipalArn": backup_vault_admin_arn_templates
                   }
                 }
+              },
+              {
+                "Sid": "AllowCopiesForRestores",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": [{ "Ref": "CentralBackupServiceRoleArn" }]
+                },
+                "Action": ["backup:CopyIntoBackupVault"],
+                "Resource": "*"
               }
             ]
           }
@@ -265,7 +300,7 @@
               "Action": ["sts:AssumeRole"],
               "Condition": {
                 "ArnEquals": {
-                  "aws:SourceArn": ${jsonencode(member_eventbridge_rule_arn_templates)}
+                  "aws:SourceArn": member_eventbridge_rule_arn_templates
                 }
               }
             }
@@ -300,8 +335,8 @@
           "detail": {
             "$or": [
               { "backupVaultName": [{ "Ref": "BackupVaultName" }] },
-              { "sourceBackupVaultArn": ${jsonencode(central_backup_vault_arn_templates)} },
-              { "destinationBackupVaultArn": ${jsonencode(central_backup_vault_arn_templates)} }
+              { "sourceBackupVaultArn": central_backup_vault_arn_templates },
+              { "destinationBackupVaultArn": central_backup_vault_arn_templates }
             ]
           }
         },
@@ -361,14 +396,11 @@
                 "Resource": "*",
                 "Condition": {
                   "ArnNotLike": {
-                    "aws:PrincipalArn": [
-                      { "Fn::GetAtt": ["DeploymentHelperRole", "Arn"] },
-                      { "Fn::Sub": "arn:$${AWS::Partition}:iam::$${AWS::AccountId}:role/$${BackupServiceRoleName}" },
-                      { "Fn::Sub": "arn:$${AWS::Partition}:iam::$${AWS::AccountId}:role/OrganizationAccountAccessRole" }
-                    ]
+                    "aws:PrincipalArn": backup_vault_admin_arn_templates
                   }
                 }
               }
+              # BackupServiceRole is allowed to copy into the restore vault via same-account permission policy.
             ]
           }
         }
@@ -381,4 +413,4 @@
       "Value": { "Ref": "BackupServiceLinkedRoleArn" }
     }
   }
-}
+})}

--- a/modules/service-deployment/variables.tf
+++ b/modules/service-deployment/variables.tf
@@ -21,11 +21,6 @@ variable "backup_tag_key" {
   }
 }
 
-variable "central_backup_service_role_arn" {
-  description = "The ARN of the central backup service role, used to copy backups between vaults."
-  type        = string
-}
-
 variable "central_backup_service_linked_role_arn" {
   description = "The ARN of the AWS Backup service-linked role in the central account. Required to be added to custom KMS Key Policies in member accounts."
   type        = string


### PR DESCRIPTION
- Moves the Backup Service Role to be per deployment, required to restrict principals that can copy into the workload account `-cmk` vault.
- Adds Step Function for return path copying.