### PR TITLE
Require `hashicorp/aws` >= 6.4.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "> 6.0.0"
+      version = ">= 6.4.0"
     }
   }
 }


### PR DESCRIPTION
We're using the `skip_destroy` argument on `resource/aws_s3_bucket_public_access_block`.