### PR TITLE
Revert changes apart from plan name

### DIFF
--- a/examples/tags/locals.tf
+++ b/examples/tags/locals.tf
@@ -23,12 +23,12 @@ locals {
         {
           name                = "weekly",
           schedule_expression = local.schedule_weekly
-          delete_after_days   = 30
+          delete_after_days   = 8
         },
         {
           name                = "monthly",
           schedule_expression = local.schedule_monthly
-          delete_after_days   = 90
+          delete_after_days   = 9
         }
       ]
     }

--- a/examples/tags/main.tf
+++ b/examples/tags/main.tf
@@ -9,7 +9,7 @@ module "aws_backup" {
     "ca-prod" = {
       backup_targets                  = [module.ou_data_lookup.by_name_path["Workloads / Serverless / CA / RSA CA"].id]
       min_retention_days              = 7
-      max_retention_days              = 90
+      max_retention_days              = 12
       allow_backup_targets_to_restore = true
       backup_tag_key                  = "BackupPolicy"
       plans                           = local.ca_default_plans


### PR DESCRIPTION
to avoid issues when updating vaults with compliance locks