### PR TITLE
Restrict Terraform and provider versions within Deployment Helper Lambda

### DIFF
--- a/modules/deployment-helper-regional/src/terraform-stacks/AWS_Backup_BackupVault.tf
+++ b/modules/deployment-helper-regional/src/terraform-stacks/AWS_Backup_BackupVault.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.11.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 6.14.1"
+    }
+  }
+}
+
 variable "AccessPolicy" {
   type    = string
   default = ""


### PR DESCRIPTION
The AWS provider has been growing in size to the point we had to increase the Deployment Helper Lambda's ephemeral storage. Pinning to a provider version should prevent this being an issue in production.