### PR TITLE
Reduce permissions for DeploymentHelperRole

### DIFF
--- a/modules/service-deployment/templates/stackset.json.tftpl
+++ b/modules/service-deployment/templates/stackset.json.tftpl
@@ -279,7 +279,27 @@ ${jsonencode({
             }
           ]
         },
-        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/AdministratorAccess"]
+        "Policies": [
+          {
+            "PolicyName": { "Fn::Sub": "$${DeploymentHelperRoleNamePrefix}$${AWS::Region}" },
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": "iam:CreateServiceLinkedRole",
+                  "Resource": "*",
+                  "Condition": {
+                    "StringEquals": {
+                      "iam:AWSServiceName": "backup.amazonaws.com"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "ManagedPolicyArns": ["arn:aws:iam::aws:policy/PowerUserAccess"]
       }
     },
     "EventBridgeRole": {


### PR DESCRIPTION
Replaces AdministratorAccess with PowerUserAccess and `iam:CreateServiceLinkedRole`. This prevents this role being used to create new identities (persistence), whilst maintaining the permissions needed to manage backups across many services. This role requires high permissions as it's used by Terraform to force delete backup vaults on destroy, which means it needs permissions to delete backups within many AWS services.