### PR TITLE
Use local> prefix for Renovate preset references

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>nationalarchives/renovate-config",
-    "github>nationalarchives/renovate-config:github-actions",
-    "github>nationalarchives/renovate-config:python-packages"
+    "local>nationalarchives/renovate-config",
+    "local>nationalarchives/renovate-config:github-actions",
+    "local>nationalarchives/renovate-config:python-packages"
   ]
 }


### PR DESCRIPTION
Switch from `github>` to `local>` prefix for preset references.

The `local>` prefix tells Renovate to resolve presets using the same platform credentials it already has, allowing it to read from internal repositories. This fixes the `undefined` error when consumer repos try to fetch presets from the internal `renovate-config` repository.

See [Renovate docs: Local presets](https://docs.renovatebot.com/config-presets/#local-presets).