### PR TITLE
fix: Exclude Terraform AWS Provider from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,12 @@
     "github>nationalarchives/renovate-config",
     "github>nationalarchives/renovate-config:github-actions",
     "github>nationalarchives/renovate-config:python-packages"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["terraform"],
+      "matchPackageNames": ["hashicorp/aws"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
The Terraform AWS provider version should only be updated when needed, in which case it should be done manually by the developer.